### PR TITLE
Fixed "No examples requests" on Windows

### DIFF
--- a/src/Providers/EnlightenServiceProvider.php
+++ b/src/Providers/EnlightenServiceProvider.php
@@ -49,14 +49,10 @@ class EnlightenServiceProvider extends ServiceProvider
 
         if ($this->app->runningInConsole()) {
             $this->loadMigrationsFrom($this->packageRoot('database/migrations'));
-
+            $this->registerMiddleware();
             $this->registerPublishing();
 
             $this->registerCommands();
-        }
-
-        if ($this->app->runningUnitTests()) {
-            $this->registerMiddleware();
         }
     }
 


### PR DESCRIPTION
When using `php unit` or `php artisan test` on Windows, 
`$this->app->runningUnitTests()` is always `false` so the middleware that create the requests examples never runs.