### PR TITLE
Fix replaceValue method crash when paylod is just a string

### DIFF
--- a/src/Models/ReplacesValues.php
+++ b/src/Models/ReplacesValues.php
@@ -19,7 +19,13 @@ trait ReplacesValues
         }
 
         if (is_string($values)) {
+            $originalString = $values;
+
             $values = json_decode($values, JSON_OBJECT_AS_ARRAY);
+        }
+
+        if (is_null($values)) {
+            return [$originalString];
         }
 
         return collect($values)


### PR DESCRIPTION
In all cases we are assuming that the response payload to pars with `Styde\Enlighten\Models\ReplacesValues` trait is either null or an object/array. But when we are returning just a plain string like:
```php
        return response()->json('Unsubscription was successfully', 200);
```

Then we get an exception coz array_intersect_key can't use the string (see attached image).

This fix will return the plain string response if we cant json decode it.
Fixes #55