### PR TITLE
Handle missing TestCase class

### DIFF
--- a/src/Console/Commands/InstallCommand.php
+++ b/src/Console/Commands/InstallCommand.php
@@ -20,7 +20,6 @@ class InstallCommand extends Command
         if ($this->setupEnlightenInTestCase()) {
             $this->info('Installation complete!');
         } else {
-            $this->error('The installer has detected changes in your TestCase class.');
             $this->error('Please setup Enlighten manually with the link below:');
             $this->error('https://github.com/StydeNet/enlighten#manual-setup');
         }
@@ -38,10 +37,16 @@ class InstallCommand extends Command
 
     private function setupEnlightenInTestCase()
     {
-        $appTestCase = File::get(base_path('tests/TestCase.php'));
+    	try {
+            $appTestCase = File::get(base_path('tests/TestCase.php'));
+	    } catch (\Throwable $throwable) {
+			$this->error('The installer could not load your TestCase class. Maybe it has been moved from the default location?');
+			return false;
+	    }
         $baseTestCase = File::get(__DIR__.'/stubs/BaseTestCase.php.stub');
 
         if ($appTestCase != $baseTestCase) {
+        	$this->error('The installer has detected changes in your TestCase class.');
             return false;
         }
 


### PR DESCRIPTION
If this TestCase class is missing, the installer command will fail:

![image](https://user-images.githubusercontent.com/5255492/115525140-bcb18500-a286-11eb-9efc-2dc6676df219.png)

This PR adds a try catch and shows an error message to say the class could not be found, allowing the command to complete whilst still telling the user a manual install will need to be done.